### PR TITLE
FIXME:Minimal pgen plot

### DIFF
--- a/pygor3/scripts/cli.py
+++ b/pygor3/scripts/cli.py
@@ -2672,8 +2672,8 @@ cli.add_command(database_naive_align)
 
 @click.option("-D", "--set_database", "igor_fln_db", default=None, help="Igor database created with database script.")
 ############## COMMON options ##############
-@click.option("--igor-scenarios", "igor_fln_output_scenarios", default=None, help="igor generated scenarios filename.", required=True)
-@click.option("--airr-scenarios", "airr_fln_output_scenarios", default=None, help="AIRR formatted scenarios filename.", required=True)
+@click.option("--igor-scenarios", "igor_fln_output_scenarios", default=None, help="igor generated scenarios filename.", required=False)
+@click.option("--airr-scenarios", "airr_fln_output_scenarios", default=None, help="AIRR formatted scenarios filename.", required=False)
 ############## NO COMMON options ##############
 def test(igor_species, igor_chain, igor_model, igor_model_path, igor_fln_db,
          igor_fln_output_scenarios, airr_fln_output_scenarios):
@@ -2708,8 +2708,20 @@ def test(igor_species, igor_chain, igor_model, igor_model_path, igor_fln_db,
 
     # igortask.load_IgorModel()
     igortask.load_mdl_from_db()
+    pgen_records = igortask.igor_db.fetch_IgorPgen()
+    import numpy as np
+    np_pgen_records = np.array(pgen_records)
+    np_log_pgens = np.log(np_pgen_records[:, 1])
+    hist, bin_edges = np.histogram(np_log_pgens)
+    bins = 0.5*(bin_edges[:-1]+ bin_edges[1:])
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+    ax.set_xlabel("$\log(Pgen)$")
+    ax.set_ylabel("Counts")
+    ax.plot(bins, hist, marker='o')
+    plt.show()
 
-    igortask.igor_db.export_IgorBestScenarios_to_AIRR("nose.tsv")
+    # igortask.igor_db.export_IgorBestScenarios_to_AIRR("nose.tsv")
 
 
 
@@ -3107,7 +3119,7 @@ def demo_get_data():
     #
 
 cli.add_command(demo_get_data)
-# cli.add_command(test)
+cli.add_command(test)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

In this pull request, the following changes have been made to the Python script `cli.py` in the `pygor3/scripts` directory:

- Modified the CLI options `igor-scenarios` and `airr-scenarios` in the `test` function to be not required.
- Added a data visualization plot using matplotlib to display a histogram of logarithmically transformed data.
- Commented out the call to `export_IgorBestScenarios_to_AIRR` method in the `test` function.
- Enabled the `test` command in the CLI by uncommenting `cli.add_command(test)`.

Summary of changes:
- Updated CLI options `igor-scenarios` and `airr-scenarios` to be not required.
- Added data visualization plot using matplotlib to display histogram of transformed data.
- Commented out call to `export_IgorBestScenarios_to_AIRR` method.
- Enabled `test` command in the CLI.

These changes aim to improve the functionality of the script by providing a visualization of the data using a histogram plot and making the CLI options more flexible by allowing them to be not required.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Make the `--igor-scenarios` and `--airr-scenarios` options non-required in the CLI, add a minimal plot for Pgen values using matplotlib, and enable the `test` command in the CLI.

### Why are these changes being made?

The change to make the scenario options non-required allows for more flexible command-line usage when scenarios are not necessary. The addition of a minimal Pgen plot provides a visual representation of the Pgen distribution, which can be useful for analysis and debugging. Enabling the `test` command in the CLI makes it accessible for users to execute.

<!-- Korbit AI PR Description End -->