### PR TITLE
Bump requests from 2.25.1 to 2.31.0 in /docs/source

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -12,7 +12,7 @@ numpy==1.19.5
 packaging==20.9
 pandas==1.2.4
 panel==0.12.6
-requests==2.25.1
+requests==2.31.0
 sonia==0.0.45
 tqdm==4.61.1
 xarray==0.18.2


### PR DESCRIPTION
### Description

In this pull request, the version for the `requests` library in the `requirements.txt` file is being updated from `2.25.1` to `2.31.0`.

Changes:
- Update requests library version from `2.25.1` to `2.31.0` in `requirements.txt`